### PR TITLE
lib: add devShell derivation to iso store content

### DIFF
--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -26,6 +26,7 @@ lib.nixosSystem (args // {
               nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
               isoImage.storeContents = [
                 self.devShell.${config.nixpkgs.system}
+                self.devShell.${config.nixpkgs.system}.drvPath
                 hostConfig.system.build.toplevel
                 hostConfig.system.build.toplevel.drvPath
               ];


### PR DESCRIPTION
This is intended to cache avaluation and thereby cut evaulation
times within a live iso environment.

closes: #195