### PR TITLE
lib: ensure path type in mkProfileAttrs

### DIFF
--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -27,7 +27,7 @@ let mkProfileAttrs =
     f = n: _:
       lib.optionalAttrs
         (lib.pathExists "${dir}/${n}/default.nix")
-        { default = "${dir}/${n}"; }
+        { default = /. + "${dir}/${n}"; }
       // mkProfileAttrs "${dir}/${n}";
   in
   lib.mapAttrs f imports;


### PR DESCRIPTION
This is required since in
```nix
{
              disabledModules = lib.remove modules.core suites.allProfiles;
}
```

```nix
{
   builtins.typeOf modules.core # path
}
```